### PR TITLE
Fix focus issue

### DIFF
--- a/js/dataTables.cellEdit.js
+++ b/js/dataTables.cellEdit.js
@@ -115,9 +115,11 @@ jQuery.fn.dataTable.Api.register('MakeCellsEditable()', function (settings) {
                     // Buton CSS
                     var confirmCss = settings.confirmationButton.confirmCss;
                     var cancelCss = settings.confirmationButton.cancelCss;
-                    $(cell).html("<input class='" + inputCss + "'></input>&nbsp;<a href='#' class='" + confirmCss + "' onclick='$(this).updateEditableCell(this)'>Confirm</a> <a href='#' class='" + cancelCss + "' onclick='$(this).cancelEditableCell(this)'>Cancel</a> ");
+                    $(cell).html("<input id='ejbeatycelledit' class='" + inputCss + "'></input>&nbsp;<a href='#' class='" + confirmCss + "' onclick='$(this).updateEditableCell(this)'>Confirm</a> <a href='#' class='" + cancelCss + "' onclick='$(this).cancelEditableCell(this)'>Cancel</a> ");
+                    $('#ejbeatycelledit').focus();
                 } else {
-                    $(cell).html("<input class='" + inputCss + "' onfocusout='$(this).updateEditableCell(this)'></input>");
+                    $(cell).html("<input id='ejbeatycelledit' class='" + inputCss + "' onfocusout='$(this).updateEditableCell(this)'></input>");
+                    $('#ejbeatycelledit').focus();
                 }
 
             }


### PR DESCRIPTION
This fixes an issue I had with https://github.com/ejbeaty/CellEdit/issues/1

The problem occurs on all major browsers I tested with.

Before this PR - if you click a cell, and then immediately click a second cell, you can end up with an edit field for both fields simultaneously. The reason is the first cell does not necessarily ever actually get "focus" - therefore it never loses focus, and so the event is not triggered.

This PR ensures the edit field _always _ gets focus - and prevents duplicate simultaneous edits.