### PR TITLE
Null Checking setting.inputTypes for Issue#7

### DIFF
--- a/js/dataTables.cellEdit.js
+++ b/js/dataTables.cellEdit.js
@@ -122,12 +122,14 @@ function getInputHtml(currentColumnIndex, settings, oldValue) {
 
     input = {"focus":true,"html":null}
 
-    $.each(settings.inputTypes, function (index, setting) {
-        if (setting.column == currentColumnIndex) {
-            inputSetting = setting;
-            inputType = inputSetting.type.toLowerCase();
-        }
-    });
+    if(settings.inputTypes){
+		$.each(settings.inputTypes, function (index, setting) {
+			if (setting.column == currentColumnIndex) {
+				inputSetting = setting;
+				inputType = inputSetting.type.toLowerCase();
+			}
+		});
+	}
     
     if (settings.inputCss) { inputCss = settings.inputCss; }
     if (settings.confirmationButton) {


### PR DESCRIPTION
Basic example didn't work because nothing was being set to
settings.inputTypes. Null checking that field should make the example
valid.