### PR TITLE
Deferred on update event

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This plugin allows cells within a [DataTable](https://datatables.net/) to be edi
 ##### Settings { JSON Object  }
 Property | Type | Default | Example | Details  
 :------ | :------ | :------ | :-----| :------
-**onUpdate** | function |  | ```function(cell, row, oldValue){ } ``` | The call back function to be executed. The updated **[cell](https://datatables.net/reference/api/cell())**, **[row](https://datatables.net/reference/api/row())**, and previous value in that cell are passed as arguements. 
+**onUpdate** | function |  | ```function(cell, row, oldValue){ } ``` | The call back function to be executed. The updated **[cell](https://datatables.net/reference/api/cell())**, **[row](https://datatables.net/reference/api/row())**, and previous value in that cell are passed as arguements. This function can return a jQuery promise object. In such case, the table will be redraw when the promise is resolved.
 **inputCss** _(optional)_| string | none |```'my-css-class'```| A CSS class that will be applied to the input field
 **columns** _(optional)_| array | All columns |```[0,1,3,4]```| An array of column indexes defining the columns that you want to be editable.
 **allowNulls** _(optional)_| object | false | ```{ "columns": [4], "errorClass":"my-error"}``` | Determines which columns should allow null values to be entered and what CSS to apply if user input fails validation. If **errorClass** is null a default error class will be applied.


### PR DESCRIPTION
This is a very useful feature for me. If onUpdate returns a promise, table redraw is runned when promise is resolved.

The use case is an ajax update when a cell is modified. Using promises I'm sure the page redraw is made after ajax request success.