### PR TITLE
Make it work with Edge

### DIFF
--- a/js/dataTables.cellEdit.js
+++ b/js/dataTables.cellEdit.js
@@ -28,7 +28,7 @@ jQuery.fn.dataTable.Api.register('MakeCellsEditable()', function (settings) {
         // UPDATE
         updateEditableCell: function (callingElement) {
             // Need to redeclare table here for situations where we have more than one datatable on the page. See issue6 on github
-            var table = $(callingElement.closest("table")).DataTable().table();
+            var table = $(callingElement).closest("table").DataTable().table();
             var row = table.row($(callingElement).parents('tr'));
             var cell = table.cell($(callingElement).parent());
             var columnIndex = cell.index().column;


### PR DESCRIPTION
While this module works in Chrome and Firefox, Edge errors. When defining the table, closest() is used improperly. closest() is defined in a jQuery prototype, it cannot be used on plain JavaScript object.